### PR TITLE
V2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ your retropie. Therefore, use this at your own risk.
 ## Improvements
 
 This is the "main" feature and reason to create this tool. 
-This will allow you to easily select single or multiple updates from a mega drive.
+This will allow you to easily select single or multiple updates; either to download from a mega drive, or process updates previously downloaded from a directory on the pi.
 
 ## Fix known bugs
 
@@ -112,7 +112,7 @@ Gamelist Utilities provide a lot of functions to clean up and work with your gam
 - Remove Check/Clean Game List Logs - Allows you to delete (clean/check) log files left by previous gamelist utilities actions.
 - Manually Select Genres - Allows you to manually select official Rick Dangerous genres for roms that you have added manually, and add them to the correct collections.
 - Realign Genre Collections - Scans gamelist.xml files and completely rebuilds genre collections from gamelist entries.
-- Count of Games: Drops a counts.txt files, so you can easily validate against official game counts, it also displays it.
+- Count of Games: Displays the total game count within gamelist.xml files from selected systems. When you count all systems this will also drop a counts.txt files and a games_list.txt so you can easily validate against official game counts and view a comprehensive listing of all games.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Gamelist Utilities provide a lot of functions to clean up and work with your gam
 - Remove Check/Clean Game List Logs - Allows you to delete (clean/check) log files left by previous gamelist utilities actions.
 - Manually Select Genres - Allows you to manually select official Rick Dangerous genres for roms that you have added manually, and add them to the correct collections.
 - Realign Genre Collections - Scans gamelist.xml files and completely rebuilds genre collections from gamelist entries.
-- Count of Games: Displays the total game count within gamelist.xml files from selected systems. When you count all systems this will also drop a counts.txt files and a games_list.txt so you can easily validate against official game counts and view a comprehensive listing of all games.
+- Count of Games: Displays the total game count within gamelist.xml files from selected systems. When you count all systems this will also drop a counts.txt file and a games_list.txt file, so you can easily validate against official game counts and view a comprehensive listing of all games.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ your retropie. Therefore, use this at your own risk.
 ## Improvements
 
 This is the "main" feature and reason to create this tool. 
-This will allow you to easily select single or multiple updates; either to download from a mega drive, or process updates previously downloaded from a directory on the pi.
+This will allow you to easily select single or multiple updates to process, either; to download from a mega drive directory, or previously downloaded to a directory on the pi.
 
 ## Fix known bugs
 

--- a/install.sh
+++ b/install.sh
@@ -4,4 +4,4 @@ This script makes running the script very easy.
 It installs pip3 (necessary to install package dependencies),
 installs dependencies and starts the updater.
 '
-sudo apt-get -y install python3-pip && pip3 install -r <(curl "https://raw.githubusercontent.com/h3xp/RickDangerousUpdate/main/requirements.txt" -s -N) && python3 <(curl "https://raw.githubusercontent.com/h3xp/RickDangerousUpdate/main/install.py" -s -N) $1 $2
+sudo apt-get -y install python3-pip && pip3 install -r <(curl "https://raw.githubusercontent.com/h3xp/RickDangerousUpdate/v2.3.0/requirements.txt" -s -N) && python3 <(curl "https://raw.githubusercontent.com/h3xp/RickDangerousUpdate/v2.3.0/install.py" -s -N) $1 $2

--- a/update.py
+++ b/update.py
@@ -438,7 +438,7 @@ def check_wrong_permissions():
         permissions_dialog()
     else:
         output = runcmd('ls -la /home/pi/.emulationstation/gamelists/retropie | grep " gamelist.xml$" | cut -d \' \' -f3,4')
-        if output.rstrip() != 'pi pi':
+        if "pi" not in output.rstrip():
             permissions_dialog()
 
 
@@ -1960,8 +1960,8 @@ def main_dialog():
         if tag == "1":
             # official_improvements_dialog() is for always forcing downloading
             # improvements_dialog() is for allowing manual side loadinbg
-            #official_improvements_dialog()
-            improvements_dialog()
+            official_improvements_dialog()
+            #improvements_dialog()
         elif tag == "2":
             bugs_dialog()
         elif tag == "3":

--- a/update.py
+++ b/update.py
@@ -2062,6 +2062,11 @@ def official_improvements_dialog(update_dir=None, delete=False):
     if update_dir is not None:
         available_updates = get_manual_updates(update_dir, available_updates)
 
+    if len(available_updates) == 0:
+        d.msgbox("No updates available.")
+        cls()
+        main_dialog()
+        
     #available_updates.sort()
     available_updates = sort_official_updates(available_updates)
 

--- a/update.py
+++ b/update.py
@@ -1097,6 +1097,7 @@ def process_gamelist(system: str, gamelist_roms_dir: str, log_file: str, backup_
         src_name_node = src_game.find("name")
         if src_name_node is not None:
             src_name = src_name_node.text
+            print(src_name)
 
         # get rom file
         src_node = src_game.find("path")
@@ -1194,7 +1195,7 @@ def process_gamelist(system: str, gamelist_roms_dir: str, log_file: str, backup_
 
     # clean snaps
     if del_snaps == True:
-        process_orphaned_files(snaps_files, system_snaps, backup_snaps, log_file, "video", clean=clean)
+        process_orphaned_files(snaps_files, system_snaps, log_file, backup_snaps, "video", clean=clean)
 
     # clean m3u
     if del_m3u == True:
@@ -1925,8 +1926,8 @@ def main_dialog():
         if tag == "1":
             # official_improvements_dialog() is for always forcing downloading
             # improvements_dialog() is for allowing manual side loadinbg
-            #official_improvements_dialog()
-            improvements_dialog()
+            official_improvements_dialog()
+            #improvements_dialog()
         elif tag == "2":
             bugs_dialog()
         elif tag == "3":

--- a/update.py
+++ b/update.py
@@ -367,10 +367,8 @@ def get_available_updates(megadrive: str, status=False):
         modified_date = node["ts"]
         if node["t"] == 0:
             if status == True:
-                print("Update \"{}\" found...".format(file_name))
-            file_data = get_file_data(file_id, root_folder)
-            file_size = convert_filesize(file_data["s"])
-            #print("file_name: {}\tfile_id: {}".format(file_name, file_id))
+                #print("Update \"{}\" found...".format(file_name))
+                file_size = convert_filesize(node["s"])
             available_updates.append([file_name, file_id, modified_date, file_size])
 
     return available_updates

--- a/update.py
+++ b/update.py
@@ -1948,7 +1948,7 @@ def main_dialog():
         update_available_result - update_available()
 
     code, tag = d.menu("Main Menu", 
-                    choices=[("1", "Load Improvements"), 
+                    choices=[("1", "Load Improvements"),    
                              ("2", "Fix Known Bugs"),
                              ("3", "Miscellaneous"),
                              ("4", "Installation")],
@@ -1960,8 +1960,8 @@ def main_dialog():
         if tag == "1":
             # official_improvements_dialog() is for always forcing downloading
             # improvements_dialog() is for allowing manual side loadinbg
-            official_improvements_dialog()
-            #improvements_dialog()
+            #official_improvements_dialog()
+            improvements_dialog()
         elif tag == "2":
             bugs_dialog()
         elif tag == "3":

--- a/update.py
+++ b/update.py
@@ -1891,15 +1891,15 @@ def downloaded_update_question_dialog():
     code = d.yesno(text="You will be asked to choose a .zip file to load, or a directory where multiple .zip files are located."
                          "\nThis will process the .zip file(s)?"
                          "\n\nIf the name of a .zip file is identified as a valid official update, it will be processed as an official update package."
-                         "\n\nSelecting \"Yes\" will delete the .zip files and directories once the process is complete."
-                         "\nSelecting \"No\" will leave the .zip files and directories once the process is complete."
-                         "\n\nWould you like to remove .zip files and directories?")
+                         "\n\nSelecting \"Keep\" will keep the .zip files and directories once the process is complete."
+                         "\nSelecting \"Delete\" will delete the .zip files and directories once the process is complete."
+                         "\n\nWould you like to remove .zip files and directories?", yes_label="Keep", no_label="Delete")
 
     if code == d.OK:
-        manual_updates_dialog("/", True)
+        manual_updates_dialog("/", False)
 
     if code == d.CANCEL:
-        manual_updates_dialog("/", False)
+        manual_updates_dialog("/", True)
 
     return
 

--- a/update.py
+++ b/update.py
@@ -1825,7 +1825,7 @@ def process_manual_updates(path: str, updates: list, delete=False):
     for update in updates:
         file = os.path.join(path, update[0])
         if process_improvement(file, extracted) == True:
-            applied_updates += 0
+            applied_updates += 1
             if delete == True:
                 os.remove(file)
 
@@ -1836,7 +1836,7 @@ def process_manual_updates(path: str, updates: list, delete=False):
             if len(os.listdir(path)) == 0:
                 shutil.rmtree(path)
 
-    d.msgbox("{} of {} selected manual updates installed.".format(applied_updates, len(updates)))
+    d.msgbox("{} of {} selected manual updates installed.".format(str(applied_updates), len(updates)))
     reboot_msg = "\nRebooting in 5 seconds!\n"
     d.pause(reboot_msg, height=10, width=60)
     restart_es()

--- a/update.py
+++ b/update.py
@@ -1821,9 +1821,11 @@ def get_manual_updates(path: str, available_updates: list):
 def process_manual_updates(path: str, updates: list, delete=False):
     extracted = Path("/", "tmp", "extracted")
 
+    applied_updates = 0
     for update in updates:
         file = os.path.join(path, update[0])
         if process_improvement(file, extracted) == True:
+            applied_updates += 0
             if delete == True:
                 os.remove(file)
 
@@ -1834,7 +1836,8 @@ def process_manual_updates(path: str, updates: list, delete=False):
             if len(os.listdir(path)) == 0:
                 shutil.rmtree(path)
 
-    reboot_msg = "\nUpdates installed, rebooting in 5 seconds!\n"
+    d.msgbox("{} of {} selected manual updates installed.".format(applied_updates, len(updates)))
+    reboot_msg = "\nRebooting in 5 seconds!\n"
     d.pause(reboot_msg, height=10, width=60)
     restart_es()
 
@@ -2195,8 +2198,9 @@ def do_improvements(selected_updates: list, megadrive: str):
         except OSError as e:
             print("Error: %s : %s" % (improvements_dir, e.strerror))
     
+    d.msgbox("{} of {} selected updates installed.".format(len(installed_updates), len(selected_updates)))
     if len(installed_updates) > 0:
-        reboot_msg = "\n{} of {} selected updates installed, rebooting in 5 seconds!\n".format(len(installed_updates), len(selected_updates))
+        reboot_msg = "\nRebooting in 5 seconds!\n".format(len(installed_updates), len(selected_updates))
         d.pause(reboot_msg, height=10, width=60)
         restart_es()
     else:

--- a/update.py
+++ b/update.py
@@ -1479,12 +1479,14 @@ def count_games(system: str, games: list):
     for src_game in src_root.iter("game"):
         game = src_game.find("name")
         if game.text is not None:
-            games_list.append(game.text)
-            count += 1
+            path = src_game.find("path")
+            if path.text is not None:
+                games_list.append((game.text.strip(), path.text.strip()))
+                count += 1
 
     games_list.sort()
     for list_game in games_list:
-        games.append((system, list_game))
+        games.append((system, list_game[0], list_game[1].replace("./", "")))
 
     return count
 
@@ -1515,7 +1517,7 @@ def gamelist_counts_dialog(systems: list, all_systems=False):
             f.write(systems_text)
 
         for game in games:
-            games_text += "{}\t{}\n".format(game[0], game[1])
+            games_text += "{}\t{}\t{}\n".format(game[0], game[1], game[2])
         with open("/home/pi/.update_tool/games_list.txt", 'w', encoding='utf-8') as f:
             f.write(games_text)
 

--- a/update.py
+++ b/update.py
@@ -817,6 +817,8 @@ def parse_m3u_file(m3u_file: str, system_rom_directory: str):
         for line in m3ufile:
             if len(line.strip()) == 0:
                 continue
+            if line.strip()[0:1] == "#":
+                continue
             files.append(os.path.join(system_rom_directory, line.strip()))
 
     return files
@@ -2017,6 +2019,9 @@ def official_improvements_dialog(update_dir=None, delete=False):
     megadrive = check_drive()
     check_wrong_permissions()
     reboot_msg = "Updates installed:"
+    title_msg  = "Download and Install Official Updates"
+    if update_dir is not None:
+        title_msg  = "Manually Install Official Updates"
 
     available_updates = get_available_updates(megadrive, status=True)
     if update_dir is not None:
@@ -2034,7 +2039,7 @@ def official_improvements_dialog(update_dir=None, delete=False):
                              ok_label="Apply Selected", 
                              extra_button=True, 
                              extra_label="Apply All", 
-                             title="Download and Install Official Updates")
+                             title=title_msg)
 
     selected_updates = []
     if code == d.OK:

--- a/update.py
+++ b/update.py
@@ -884,9 +884,9 @@ def process_supporting_files(src_game: ET.Element, src_name: str, subelement_nam
 
     # delete validated files
     if len(file) > 0:
+        if file not in found_files:
+            found_files.append(file)
         if file in supporting_files:
-            if file not in found_files:
-                found_files.append(file)
             index = supporting_files.index(file)
             del supporting_files[index]
 
@@ -908,7 +908,7 @@ def process_orphaned_files(orphaned_files: list, dir: str, log_file: str, dir_ba
 
 
 def delete_gamelist_entry_dialog(rom: str):
-    code = d.yesno("Gamelist entry for {} has invalid rom entries, would you like to remove it from your gamelist.xml?".format(rom))
+    code = d.yesno("Gamelist entry for \"{}\" has invalid rom entries (rom files or multi disk files defined in .m3u or .cue file can not be found).\nWould you like to remove it from your gamelist.xml?".format(rom))
 
     if code == d.OK:
         return True
@@ -1906,7 +1906,10 @@ def main_dialog():
     
     if code == d.OK:
         if tag == "1":
+            # official_improvements_dialog() is for always forcing downloading
+            # improvements_dialog() is for allowing manual side loadinbg
             official_improvements_dialog()
+            #improvements_dialog()
         elif tag == "2":
             bugs_dialog()
         elif tag == "3":

--- a/update.py
+++ b/update.py
@@ -1496,7 +1496,7 @@ def gamelist_counts_dialog(systems: list, all_systems=False):
     systems_text = ""
     total_count = 0
     games = []
-    games_text = "system\tgame\n"
+    games_text = "system\tgame\tpath\n"
     for system in systems:
         for single_system in system.split("/"):
             system_count = count_games(single_system, games)

--- a/update_tool.ini
+++ b/update_tool.ini
@@ -1,5 +1,5 @@
 [CONFIG_ITEMS]
-tool_ver = 2.2.1
+tool_ver = 2.3.0
 home_dir = /home/pi/.update_tool
 home_command = update.py
 home_exe = python3

--- a/update_tool.ini
+++ b/update_tool.ini
@@ -25,6 +25,7 @@ Puzzle = custom-puzzle.cfg
 Racing = custom-racing.cfg
 Role Playing Games = custom-rpgs.cfg
 Shoot'em up = custom-shmups.cfg
+Shoot'em up/Vertical = custom-shmups.cfg
 Simulation = custom-simulation.cfg
 Sports = custom-sports.cfg
 Strategy = custom-strategy.cfg


### PR DESCRIPTION
NEW in v2.3.0!
- Manual Install Downloaded Updates: process manually downloaded official updates.
- Counts: now dumps a list of all games when you count all systems.
- NEW official update sorting algorithm to ensure update 100 will sort properly.
- Enhanced update screen with file sizes.
- Improved logic of finding orphaned files through gamelist check/clean utilities.
- Download/Process files until you hit download limits.
- Updated genres mapping.

Fixed in v2.3.0...
- Downloading updates will process after each file is downloaded, and will not error out when mega download limit is reached.