### PR TITLE
v2.3.1

### DIFF
--- a/update.py
+++ b/update.py
@@ -1858,15 +1858,6 @@ def get_valid_path_portion(path: str):
     return return_path
 
 
-def save_default_updates_dir_dialog(update_dir: str):
-    code = d.yesno(text="Do you want to make your selection \"" + update_dir + "\" permanently set as default value for the update directory?")
-
-    if code == d.OK:
-        set_config_value("CONFIG_ITEMS", "update_dir", update_dir)
-
-    return
-
-
 def manual_updates_dialog(init_path: str, delete: bool):
     help_text = ("Type the path to directory or file directly into the text entry window."
                   "\nAs you type the directory or file will be highlighted, at this point you can press [Space] to add the highlighted item to the path."
@@ -1876,7 +1867,7 @@ def manual_updates_dialog(init_path: str, delete: bool):
 
     if code == d.OK:
         if os.path.isdir(path) or os.path.isfile(path):
-            save_default_updates_dir_dialog(path)
+            set_config_value("CONFIG_ITEMS", "update_dir", path)
             official_improvements_dialog(path, delete)
         else:
             d.msgbox("Invalid path!")

--- a/update.py
+++ b/update.py
@@ -1836,10 +1836,10 @@ def process_manual_updates(path: str, updates: list, delete=False):
 
             set_config_value("INSTALLED_UPDATES", update[0], str(update[2]))
 
-    if os.path.isdir(path):
-        if delete == True:
-            if len(os.listdir(path)) == 0:
-                shutil.rmtree(path)
+#    if os.path.isdir(path):
+#        if delete == True:
+#            if len(os.listdir(path)) == 0:
+#                shutil.rmtree(path)
 
     d.msgbox("{} of {} selected manual updates installed.".format(str(applied_updates), len(updates)))
     reboot_msg = "\nRebooting in 5 seconds!\n"
@@ -1906,9 +1906,9 @@ def downloaded_update_question_dialog():
     code = d.yesno(text="You will be asked to choose a .zip file to load, or a directory where multiple .zip files are located."
                         "\nThis will process the .zip file(s)?"
                         "\n\nIf the name of a .zip file is identified as a valid official update, it will be processed as an official update package."
-                        "\n\nSelecting \"Keep\" will keep the .zip files and directories once the process is complete."
-                        "\nSelecting \"Delete\" will delete the .zip files and directories once the process is complete."
-                        "\n\nWould you like to remove .zip files and directories?", yes_label="Keep", no_label="Delete")
+                        "\n\nSelecting \"Keep\" will keep the .zip files once the process is complete."
+                        "\nSelecting \"Delete\" will delete the .zip files once the process is complete."
+                        "\n\nWould you like to remove .zip files?", yes_label="Keep", no_label="Delete")
 
     update_dir = get_default_update_dir()
     

--- a/update.py
+++ b/update.py
@@ -2335,8 +2335,8 @@ def multiple_overlays_dialog(enable_disable = "Enable"):
 
 
     if code == d.EXTRA:
-        for system in menu_choices[0]:
-            do_system_overlay(system, enable_disable)
+        for menu_choice in menu_choices:
+            do_system_overlay(menu_choice[0], enable_disable)
 
     cls()
     overlays_dialog()

--- a/update.py
+++ b/update.py
@@ -1858,7 +1858,22 @@ def get_valid_path_portion(path: str):
     return return_path
 
 
+def get_default_update_dir():
+    if os.path.exists("/home/pi/.update_tool/update_tool.ini"):
+        update_dir = get_config_value("CONFIG_ITEMS", "update_dir")
+        if update_dir is not None:
+            return update_dir
+
+    return None
+
+
 def manual_updates_dialog(init_path: str, delete: bool):
+    update_dir = get_default_update_dir()
+    if update_dir is not None:
+        if os.path.isdir(update_dir) or os.path.isfile(update_dir):
+            official_improvements_dialog(update_dir, delete)
+            return
+            
     help_text = ("Type the path to directory or file directly into the text entry window."
                   "\nAs you type the directory or file will be highlighted, at this point you can press [Space] to add the highlighted item to the path."
                   "\n\nIf you are adding a directory to the text entry window, and the path ends with a \"/\", the files in that directory will automatically show in the \"Files\" window."
@@ -1887,7 +1902,24 @@ def manual_updates_dialog(init_path: str, delete: bool):
     return
 
 
+def get_default_delete_updates():
+    if os.path.exists("/home/pi/.update_tool/update_tool.ini"):
+        delete_updates = get_config_value("CONFIG_ITEMS", "delete_updates")
+        if delete_updates is not None:
+            return delete_updates
+
+    return None
+
+
 def downloaded_update_question_dialog():
+    delete_updates = get_default_delete_updates()
+    if delete_updates == "True":
+        manual_updates_dialog("/", True)
+        return
+    elif delete_updates == "False":
+        manual_updates_dialog("/", False)
+        return
+
     code = d.yesno(text="You will be asked to choose a .zip file to load, or a directory where multiple .zip files are located."
                          "\nThis will process the .zip file(s)?"
                          "\n\nIf the name of a .zip file is identified as a valid official update, it will be processed as an official update package."

--- a/update.py
+++ b/update.py
@@ -1858,6 +1858,14 @@ def get_valid_path_portion(path: str):
     return return_path
 
 
+def save_default_updates_dir_dialog(update_dir: str):
+    code = d.yesno(text="Do you want to make your selection \"" + update_dir + "\" permanently set as default value for the update directory?")
+
+    if code == d.OK:
+        set_config_value("CONFIG_ITEMS", "update_dir", update_dir)
+
+    return
+
 
 def manual_updates_dialog(init_path: str, delete: bool):
     help_text = ("Type the path to directory or file directly into the text entry window."
@@ -1868,6 +1876,7 @@ def manual_updates_dialog(init_path: str, delete: bool):
 
     if code == d.OK:
         if os.path.isdir(path) or os.path.isfile(path):
+            save_default_updates_dir_dialog(path)
             official_improvements_dialog(path, delete)
         else:
             d.msgbox("Invalid path!")
@@ -1888,20 +1897,6 @@ def manual_updates_dialog(init_path: str, delete: bool):
     return
 
 
-def get_default_delete_updates():
-    if os.path.exists("/home/pi/.update_tool/update_tool.ini"):
-        delete_updates = get_config_value("CONFIG_ITEMS", "delete_updates")
-        if delete_updates is not None:
-            if delete_updates == "True":
-                return True
-            elif delete_updates == "False":
-                return False
-            else:
-                return None
-
-    return None
-
-
 def get_default_update_dir():
     if os.path.exists("/home/pi/.update_tool/update_tool.ini"):
         update_dir = get_config_value("CONFIG_ITEMS", "update_dir")
@@ -1920,18 +1915,13 @@ def downloaded_update_question_dialog():
                         "\n\nWould you like to remove .zip files and directories?", yes_label="Keep", no_label="Delete")
 
     update_dir = get_default_update_dir()
-    delete_updates = get_default_delete_updates()
     
     if os.path.isdir(update_dir) or os.path.isfile(update_dir):
-        if delete_updates is None:
-            if code == d.OK:
-                manual_updates_dialog(update_dir, False)
+        if code == d.OK:
+            manual_updates_dialog(update_dir, False)
 
-            if code == d.CANCEL:
-                manual_updates_dialog(update_dir, True)
-
-        else:
-            manual_updates_dialog(update_dir, delete_updates)
+        if code == d.CANCEL:
+            manual_updates_dialog(update_dir, True)
 
     return
 

--- a/update.py
+++ b/update.py
@@ -1367,8 +1367,13 @@ def gamelist_genres_dialog(system: str, game: dict, elem: ET.Element):
     dialog_text += "\n\nSelect Genre:"
 
     code, tag = d.radiolist(text=dialog_text,
-                             choices=menu_choices, 
+                             choices=menu_choices,
+                             extra_button=True, 
+                             extra_label="Skip", 
                              title="Manually Select Genres")
+
+    if code == d.EXTRA:
+        return True
 
     if code == d.OK:
         genre = elem.find("genre")

--- a/update_tool.ini
+++ b/update_tool.ini
@@ -1,5 +1,5 @@
 [CONFIG_ITEMS]
-tool_ver = 2.3.0
+tool_ver = 2.3.1
 home_dir = /home/pi/.update_tool
 home_command = update.py
 home_exe = python3

--- a/update_tool.ini
+++ b/update_tool.ini
@@ -12,8 +12,6 @@ theme_dir = theme_hacks
 mega_dir =
 check_gamelists_roms_dir = /home/pi/RetroPie/roms
 #update_dir = /foldername
-#delete_updates = False
-#delete_updates = True
 
 [INSTALLED_UPDATES]
 

--- a/update_tool.ini
+++ b/update_tool.ini
@@ -11,6 +11,9 @@ git_exe = bash
 theme_dir = theme_hacks
 mega_dir =
 check_gamelists_roms_dir = /home/pi/RetroPie/roms
+#update_dir = /foldername
+#delete_updates = False
+#delete_updates = True
 
 [INSTALLED_UPDATES]
 


### PR DESCRIPTION
NEW in v2.3.1!
- Ability to skip a manual genre tag and continue processing.
- Manual updates will no longer delete the directory if "delete" is selected.
- Manual updates will default to "keep" files, and remember the last directory used.

Fixed in v2.3.1...
- Enable/Disable all system overlays error.

