### PR TITLE
fix: invalid path in update_dir param

### DIFF
--- a/update.py
+++ b/update.py
@@ -2734,4 +2734,6 @@ def main():
     else:
         user_dialog()
 
-main()
+# https://stackabuse.com/what-does-if-__name__-__main__-do-in-python/
+if __name__ == "__main__":
+    main()

--- a/update.py
+++ b/update.py
@@ -2042,12 +2042,15 @@ def downloaded_update_question_dialog():
 
     update_dir = get_default_update_dir()
     
-    if os.path.isdir(update_dir) or os.path.isfile(update_dir):
-        if code == d.OK:
-            manual_updates_dialog(update_dir, False)
+    if not os.path.isdir(update_dir) and not os.path.isfile(update_dir):
+        d.msgbox("Previous used path '{}' is not valid. Using /".format(update_dir))
+        update_dir = "/"
 
-        if code == d.CANCEL:
-            manual_updates_dialog(update_dir, True)
+    if code == d.OK:
+        manual_updates_dialog(update_dir, False)
+
+    if code == d.CANCEL:
+        manual_updates_dialog(update_dir, True)
 
     return
 

--- a/update.py
+++ b/update.py
@@ -2041,10 +2041,7 @@ def downloaded_update_question_dialog():
                         "\n\nWould you like to remove .zip files?", yes_label="Keep", no_label="Delete")
 
     update_dir = get_default_update_dir()
-    
-    if not os.path.isdir(update_dir) and not os.path.isfile(update_dir):
-        d.msgbox("Previous used path '{}' is not valid. Using /".format(update_dir))
-        update_dir = "/"
+    update_dir = get_valid_path_portion(update_dir)
 
     if code == d.OK:
         manual_updates_dialog(update_dir, False)

--- a/update.py
+++ b/update.py
@@ -2731,6 +2731,4 @@ def main():
     else:
         user_dialog()
 
-# https://stackabuse.com/what-does-if-__name__-__main__-do-in-python/
-if __name__ == "__main__":
-    main()
+main()

--- a/update.py
+++ b/update.py
@@ -1980,15 +1980,15 @@ def process_manual_updates(path: str, updates: list, delete=False, auto_clean=Fa
 
 
 def get_valid_path_portion(path: str):
-    return_path = ""
+    return_path = "/"
     parts = path.split("/")
     for part in parts:
         if len(part) > 0:
-            if os.path.isdir(os.path.join(return_path, "/" + part)) == True or os.path.isfile(os.path.join(return_path, "/" + part)) == True:
-                return_path += "/" + part
+            if os.path.isdir(os.path.join(return_path, part)) == True or os.path.isfile(os.path.join(return_path, part)) == True:
+                return_path = os.path.join(return_path, part)
 
-    if os.path.isdir(return_path):
-        return_path += "/"
+    #will add the trailing slash if it's not already there.
+    return_path = os.path.join(return_path, '')
 
     return return_path
 

--- a/update.py
+++ b/update.py
@@ -2040,9 +2040,12 @@ def downloaded_update_question_dialog():
                         "\nSelecting \"Delete\" will delete the .zip files once the process is complete."
                         "\n\nWould you like to remove .zip files?", yes_label="Keep", no_label="Delete")
 
-    # get an empty string if path not valid and this can use in manual_updates_dialog
-    update_dir = get_valid_path_portion(get_default_update_dir())
+    update_dir = get_default_update_dir()
     
+    if not os.path.isdir(update_dir) and not os.path.isfile(update_dir):
+        d.msgbox("Previous used path '{}' is not valid. Using /".format(update_dir))
+        update_dir = "/"
+
     if code == d.OK:
         manual_updates_dialog(update_dir, False)
 

--- a/update.py
+++ b/update.py
@@ -2040,12 +2040,9 @@ def downloaded_update_question_dialog():
                         "\nSelecting \"Delete\" will delete the .zip files once the process is complete."
                         "\n\nWould you like to remove .zip files?", yes_label="Keep", no_label="Delete")
 
-    update_dir = get_default_update_dir()
+    # get an empty string if path not valid and this can use in manual_updates_dialog
+    update_dir = get_valid_path_portion(get_default_update_dir())
     
-    if not os.path.isdir(update_dir) and not os.path.isfile(update_dir):
-        d.msgbox("Previous used path '{}' is not valid. Using /".format(update_dir))
-        update_dir = "/"
-
     if code == d.OK:
         manual_updates_dialog(update_dir, False)
 


### PR DESCRIPTION
If update_dir is an invalid path, the dialog goes back to the main dialog. Now the update_dir is set to / if it is an invalid path