### PR TITLE
fix: reboot dialog

### DIFF
--- a/update.py
+++ b/update.py
@@ -1973,8 +1973,7 @@ def process_manual_updates(path: str, updates: list, delete=False, auto_clean=Fa
 
     d.msgbox("{} of {} selected manual updates installed.\n\nTotal time to process: {}".format(len(installed_updates), len(updates), str(datetime.datetime.utcnow() - start_time)[:-7]))
     reboot_msg = "\nRebooting in 5 seconds!\n"
-    d.pause(reboot_msg, height=10, width=60)
-    restart_es()
+    reboot_dialog(reboot_msg)
 
     return
 
@@ -2404,9 +2403,8 @@ def do_improvements(selected_updates: list, megadrive: str, auto_clean=False):
     
     d.msgbox("{} of {} selected updates installed.\n\nTotal time to process: {}".format(len(installed_updates), len(selected_updates), str(datetime.datetime.utcnow() - start_time)[:-7]))
     if len(installed_updates) > 0:
-        reboot_msg = "\nRebooting in 5 seconds!\n".format(len(installed_updates), len(selected_updates))
-        d.pause(reboot_msg, height=10, width=60)
-        restart_es()
+        reboot_msg = "\nRebooting in 5 seconds!\n"
+        reboot_dialog(reboot_msg)
     else:
         main_dialog()
 
@@ -2624,8 +2622,7 @@ def install_dialog():
     if code == d.OK:
         install()
         reboot_msg = "\nUpdate tool has been installed, rebooting in 5 seconds!\n"
-        d.pause(reboot_msg, height=10, width=60)
-        restart_es()
+        reboot_dialog(reboot_msg)
     return
 
 
@@ -2639,8 +2636,7 @@ def update_dialog():
         if code == d.OK:
             update()
             reboot_msg = "\nUpdate tool has been updated, rebooting in 5 seconds!\n"
-            d.pause(reboot_msg, height=10, width=60)
-            restart_es()
+            reboot_dialog(reboot_msg)
     elif update_available_result == "no update available":
         d.msgbox("You are already running the latest version.")
         main_dialog()
@@ -2657,8 +2653,7 @@ def uninstall_dialog():
     if code == d.OK:
         uninstall()
         reboot_msg = "\nUpdate tool has been uninstalled, rebooting in 5 seconds!\n"
-        d.pause(reboot_msg, height=10, width=60)
-        restart_es()
+        reboot_dialog(reboot_msg)
     return
 
 
@@ -2701,6 +2696,13 @@ def hostname_dialog():
             main_dialog()
 
         main_dialog
+
+def reboot_dialog(reboot_msg):
+    code = d.pause(reboot_msg, height=10, width=60)
+    if code == d.CANCEL:
+        main_dialog()
+    else:
+        restart_es()
 
 
 def clean_failures():

--- a/update.py
+++ b/update.py
@@ -1972,7 +1972,7 @@ def process_manual_updates(path: str, updates: list, delete=False, auto_clean=Fa
 #                shutil.rmtree(path)
 
     d.msgbox("{} of {} selected manual updates installed.\n\nTotal time to process: {}".format(len(installed_updates), len(updates), str(datetime.datetime.utcnow() - start_time)[:-7]))
-    reboot_msg = "\nRebooting in 5 seconds!\n"
+    reboot_msg = "\nReboot required for these changes to take effect. Rebooting now.!\n"
     reboot_dialog(reboot_msg)
 
     return
@@ -2403,7 +2403,7 @@ def do_improvements(selected_updates: list, megadrive: str, auto_clean=False):
     
     d.msgbox("{} of {} selected updates installed.\n\nTotal time to process: {}".format(len(installed_updates), len(selected_updates), str(datetime.datetime.utcnow() - start_time)[:-7]))
     if len(installed_updates) > 0:
-        reboot_msg = "\nRebooting in 5 seconds!\n"
+        reboot_msg = "\nReboot required for these changes to take effect. Rebooting now.!\n"
         reboot_dialog(reboot_msg)
     else:
         main_dialog()
@@ -2621,7 +2621,7 @@ def install_dialog():
 
     if code == d.OK:
         install()
-        reboot_msg = "\nUpdate tool has been installed, rebooting in 5 seconds!\n"
+        reboot_msg = "\nUpdate tool has been installed, reboot required for these changes to take effect. Rebooting now.!\n"
         reboot_dialog(reboot_msg)
     return
 
@@ -2635,7 +2635,7 @@ def update_dialog():
 
         if code == d.OK:
             update()
-            reboot_msg = "\nUpdate tool has been updated, rebooting in 5 seconds!\n"
+            reboot_msg = "\nUpdate tool has been updated, reboot required for these changes to take effect. Rebooting now.!\n"
             reboot_dialog(reboot_msg)
     elif update_available_result == "no update available":
         d.msgbox("You are already running the latest version.")
@@ -2652,7 +2652,7 @@ def uninstall_dialog():
 
     if code == d.OK:
         uninstall()
-        reboot_msg = "\nUpdate tool has been uninstalled, rebooting in 5 seconds!\n"
+        reboot_msg = "\nUpdate tool has been uninstalled, reboot required for these changes to take effect. Rebooting now.!\n"
         reboot_dialog(reboot_msg)
     return
 


### PR DESCRIPTION
Canceling the restart dialog had no effect and the host was restarted anyway. The restart dialog has been moved to a function and canceling the restart dialog now leads to calling the main dialog.